### PR TITLE
Use namespace as instance label

### DIFF
--- a/lib/ProgressTracker.pm
+++ b/lib/ProgressTracker.pm
@@ -23,8 +23,8 @@ sub new {
   $self->{pushgateway} = $params{pushgateway} || $ENV{'PUSHGATEWAY'};
   $self->warn_not_reporting if !$self->{pushgateway};
 
-  my $namespace =  $params{namespace} || $ENV{'JOB_NAMESPACE'};
-  $self->{labels}{namespace} = $namespace if $namespace;
+  my $instance =  $params{instance} || $ENV{'JOB_NAMESPACE'};
+  $self->{labels}{instance} = $instance if $instance;
 
   my $app =  $params{app} || $ENV{'JOB_APP'};
   $self->{labels}{app} = $app if $app;

--- a/t/progress_tracker.t
+++ b/t/progress_tracker.t
@@ -76,28 +76,28 @@ describe "ProgressTracker" => sub {
     }
   };
 
-  describe "namespace label" => sub {
-    it "has no namespace label by default" => sub {
+  describe "instance label" => sub {
+    it "has an empty instance label by default" => sub {
       my $tracker = ProgressTracker->new();
       $tracker->update_metrics;
 
-      ok(metrics !~ /^job_duration_seconds.*namespace=/m);
+      ok(metrics =~ /^job_duration_seconds.*instance=""/m);
     };
 
-    it "uses namespace param if given" => sub {
+    it "uses instance param if given" => sub {
       $ENV{JOB_NAMESPACE} = 'some-namespace';
-      my $tracker = ProgressTracker->new(namespace=>'override-namespace');
+      my $tracker = ProgressTracker->new(instance=>'override-instance');
       $tracker->update_metrics;
 
-      ok(metrics =~ /^job_duration_seconds\S*namespace="override-namespace"/m);
+      ok(metrics =~ /^job_duration_seconds\S*instance="override-instance"/m);
     };
 
-    it "uses JOB_NAMESPACE env var if given" => sub {
+    it "uses JOB_NAMESPACE env var as instance if given" => sub {
       $ENV{JOB_NAMESPACE} = 'some-namespace';
       my $tracker = ProgressTracker->new();
       $tracker->update_metrics;
 
-      ok(metrics =~ /^job_duration_seconds\S*namespace="some-namespace"/m);
+      ok(metrics =~ /^job_duration_seconds\S*instance="some-namespace"/m);
     };
   };
 
@@ -151,13 +151,13 @@ describe "ProgressTracker" => sub {
       ok(metrics =~ /^job_expected_success_interval\S* 67890$/m);
     };
 
-    it "works if there is a namespace label" => sub {
+    it "works if there is an instance label" => sub {
       $ENV{JOB_SUCCESS_INTERVAL} = '12345';
       $ENV{JOB_NAMESPACE} = 'some-namespace';
       my $tracker = ProgressTracker->new();
       $tracker->update_metrics;
 
-      ok(metrics =~ /^job_expected_success_interval\S*namespace="some-namespace"\S* 12345$/m);
+      ok(metrics =~ /^job_expected_success_interval\S*instance="some-namespace"\S* 12345$/m);
     };
   };
 


### PR DESCRIPTION
If we set only the job name and not the instance label, then multiple copies of this running in different namespaces will override each other -- only the job name is used as the group in pushgateway, and when something in another namespace pushes metrics with the same group, they override the ones already there.

However, there is the notion of an "instance" label which is also used as part of the group, so by using the JOB_NAMESPACE as the instance label we can keep multiple copies in different namespaces from overriding each other.

See https://github.com/prometheus/pushgateway/blob/master/README.md